### PR TITLE
No early kickoff for compiled Python files

### DIFF
--- a/ray_ci/bootstrap_linux.sh
+++ b/ray_ci/bootstrap_linux.sh
@@ -62,7 +62,7 @@ export $(python3 ci/pipeline/determine_tests_to_run.py)
 
 
 # On pull requests, allow to run on latest available image if wheels are not affected
-if [ "${BUILDKITE_PULL_REQUEST}" != "false" ] && [ "$RAY_CI_CORE_CPP_AFFECTED" != "1" ] && [ "$RAY_CI_PYTHON_DEPENDENCIES_AFFECTED" != "1" ]; then
+if [ "${BUILDKITE_PULL_REQUEST}" != "false" ] && [ "$RAY_CI_CORE_CPP_AFFECTED" != "1" ] && [ "$RAY_CI_PYTHON_DEPENDENCIES_AFFECTED" != "1" ] && [ "$RAY_CI_COMPILED_PYTHON_AFFECTED" != "1" ]; then
   export KICK_OFF_EARLY=1
   echo "Kicking off some tests early, as this is a PR, and the core C++ is not affected, and requirements are not affected. "
 else


### PR DESCRIPTION
Signed-off-by: Antoni Baum <antoni.baum@protonmail.com>

If we make changes to compiled Python code, we shouldn't early kick off, as they will not be reflected in CI.

Env var set by https://github.com/ray-project/ray/pull/29870