### PR TITLE
Fix early kick off: Add flag to disable and checkout raylet codes

### DIFF
--- a/ray_ci/bootstrap_linux.sh
+++ b/ray_ci/bootstrap_linux.sh
@@ -24,6 +24,11 @@ if [[ "$BUILDKITE_MESSAGE" =~ "[all_tests]" ]]; then
    export ALL_TESTS="1"
 fi
 
+if [[ "$BUILDKITE_MESSAGE" =~ "[no_early_kickoff]" ]]; then
+   echo "Got no early kickoff trigger - preventing early kickoff!"
+   export KICK_OFF_EARLY="0"
+fi
+
 # Convert / into _
 if [ -z "${BUILDKITE_PULL_REQUEST_BASE_BRANCH-}" ]; then
   # In branches, use the BUILDKITE_BRANCH

--- a/ray_ci/bootstrap_linux_cpu_gpu.sh
+++ b/ray_ci/bootstrap_linux_cpu_gpu.sh
@@ -5,8 +5,13 @@ echo "--- :alarm_clock: Determine if we should kick-off some steps early"
 
 # On pull requests, allow to run on latest available image if wheels are not affected
 if [ "${BUILDKITE_PULL_REQUEST}" != "false" ] && [ "$RAY_CI_CORE_CPP_AFFECTED" != "1" ] && [ "$RAY_CI_PYTHON_DEPENDENCIES_AFFECTED" != "1" ] && [ "$RAY_CI_COMPILED_PYTHON_AFFECTED" != "1" ]; then
-  export KICK_OFF_EARLY=1
-  echo "Kicking off some tests early, as this is a PR, and the core C++ is not affected, and requirements are not affected. "
+  export KICK_OFF_EARLY=${KICK_OFF_EARLY:-1}
+
+  if [ "${KICK_OFF_EARLY}" = "1" ]; then
+    echo "Kicking off some tests early, as this is a PR, and the core C++ is not affected, and requirements are not affected. "
+  else
+    echo "We could kick off tests early, but we were asked not to (KICK_OFF_EARLY=${KICK_OFF_EARLY}), so we don't."
+  fi
 else
   export KICK_OFF_EARLY=0
   echo "This is a branch build (PR=${BUILDKITE_PULL_REQUEST}) or C++ is affected (affected=$RAY_CI_CORE_CPP_AFFECTED), or requirements are affected (affected=$RAY_CI_PYTHON_DEPENDENCIES_AFFECTED). "

--- a/ray_ci/pipeline_ci.py
+++ b/ray_ci/pipeline_ci.py
@@ -8,6 +8,17 @@ from typing import Any, Callable, Dict, List, Optional, Set
 import click
 import yaml
 
+# On early kick off, restore these files to their original state for compatibility
+EARLY_KICKOFF_KEEP_ORIG = [
+    "python/ray/_raylet.pxd",
+    "python/ray/_raylet.pyi",
+    "python/ray/_raylet.pyx",
+    "python/ray/_private/",
+    "python/ray/actor.py",
+    "python/ray/runtime_context.py",
+    "python/ray/remote_function.py",
+]
+
 
 EARLY_SETUP_COMMANDS = [
     "echo '--- :running: Early kick-off: Checking out PR code revision'",
@@ -19,10 +30,7 @@ EARLY_SETUP_COMMANDS = [
         '(echo "Quick start failed: Wrong commit hash!" && exit 1)'
     ),
     # Keep _raylet files from original image
-    (
-        "git checkout master "
-        "python/ray/_raylet.pxd python/ray/_raylet.pyi python/ray/_raylet.pyx"
-    ),
+    "git checkout master " + " ".join(EARLY_KICKOFF_KEEP_ORIG),
     "BAZEL_CONFIG_ONLY=1 ./ci/env/install-bazel.sh",
     'echo "build --remote_upload_local_results=false" >> /root/.bazelrc',
     "echo 'export PS4=\"> \"' >> ~/.bashrc",

--- a/ray_ci/pipeline_ci.py
+++ b/ray_ci/pipeline_ci.py
@@ -18,6 +18,11 @@ EARLY_SETUP_COMMANDS = [
         '[[ "$(git log -1 --format="%H")" == "{git_hash}" ]] || '
         '(echo "Quick start failed: Wrong commit hash!" && exit 1)'
     ),
+    # Keep _raylet files from original image
+    (
+        "git checkout master "
+        "python/ray/_raylet.pxd python/ray/_raylet.pyi python/ray/_raylet.pyx"
+    ),
     "BAZEL_CONFIG_ONLY=1 ./ci/env/install-bazel.sh",
     'echo "build --remote_upload_local_results=false" >> /root/.bazelrc',
     "echo 'export PS4=\"> \"' >> ~/.bashrc",

--- a/ray_ci/step.json
+++ b/ray_ci/step.json
@@ -1,60 +1,55 @@
 {
-  "plugins": [
-    {
-      "ray-project/dind#v1.0.10": {
-        "network-name": "dind-network",
-        "certs-volume-name": "ray-docker-certs-client",
-        "additional-volume-mount":  "ray-volume:/ray"
-      }
-    },
-    {
-      "docker#v5.3.0": {
-        "image": "!!REPLACE!!",
-        "shell": ["/bin/bash", "-e", "-c", "-i", "-l"],
-        "shm-size": "2.5gb",
-        "propagate-environment": false,
-        "mount-checkout": false,
-        "mount-buildkite-agent": false,
-        "workdir": "/ray",
-        "add-caps": ["SYS_PTRACE"],
-        "network": "dind-network",
-        "volumes": [
-          "ray-docker-certs-client:/certs/client:ro",
-          "ray-volume:/ray-mount",
-          "/tmp/artifacts:/artifact-mount"
+    "plugins": [
+        {
+            "ray-project/dind#v1.0.10": {
+                "network-name": "dind-network",
+                "certs-volume-name": "ray-docker-certs-client",
+                "additional-volume-mount": "ray-volume:/ray",
+            }
+        },
+        {
+            "docker#v5.3.0": {
+                "image": "!!REPLACE!!",
+                "shell": ["/bin/bash", "-e", "-c", "-i", "-l"],
+                "shm-size": "2.5gb",
+                "propagate-environment": false,
+                "mount-checkout": false,
+                "mount-buildkite-agent": false,
+                "workdir": "/ray",
+                "add-caps": ["SYS_PTRACE"],
+                "network": "dind-network",
+                "volumes": [
+                    "ray-docker-certs-client:/certs/client:ro",
+                    "ray-volume:/ray-mount",
+                    "/tmp/artifacts:/artifact-mount",
+                ],
+                "environment": [
+                    "BUILDKITE_JOB_ID",
+                    "BUILDKITE_COMMIT",
+                    "BUILDKITE_LABEL",
+                    "BUILDKITE_BRANCH",
+                    "BUILDKITE_BUILD_URL",
+                    "BUILDKITE_BUILD_ID",
+                    "BUILDKITE_PARALLEL_JOB",
+                    "BUILDKITE_PARALLEL_JOB_COUNT",
+                    "BUILDKITE_MESSAGE",
+                    "BUILDKITE_BUILD_NUMBER",
+                    "PS4",
+                ],
+            }
+        },
+    ],
+    "agents": {"queue": "!!REPLACE!!"},
+    "timeout_in_minutes": 180,
+    "retry": {
+        "manual": {"permit_on_passed": true},
+        "automatic": [
+            {"exit_status": -1, "limit": 3},
+            {"exit_status": 255, "limit": 3},
         ],
-        "environment": [
-          "BUILDKITE_JOB_ID",
-          "BUILDKITE_COMMIT",
-          "BUILDKITE_LABEL",
-          "BUILDKITE_BRANCH",
-          "BUILDKITE_BUILD_URL",
-          "BUILDKITE_BUILD_ID",
-          "BUILDKITE_PARALLEL_JOB",
-          "BUILDKITE_PARALLEL_JOB_COUNT",
-          "BUILDKITE_MESSAGE",
-          "BUILDKITE_BUILD_NUMBER",
-          "PS4"
-        ]
-      }
-    }
-  ],
-  "agents": {
-    "queue": "!!REPLACE!!"
-  },
-  "timeout_in_minutes": 180,
-  "retry": {
-    "manual": {"permit_on_passed": true},
-    "automatic": [
-      {"exit_status": -1, "limit":  3},
-      {"exit_status": 255, "limit":  3}
-    ]
-  },
-  "artifact_paths": "/tmp/artifacts/.*/**",
-  "env": {
-    "BUILDKITE_ARTIFACT_UPLOAD_DESTINATION": "!!REPLACE!!",
-    "PS4": "> "
-  },
-  "notify": ["github_commit_status"],
-  "depends_on": null
+    },
+    "artifact_paths": "/tmp/artifacts/.*/**",
+    "env": {"BUILDKITE_ARTIFACT_UPLOAD_DESTINATION": "!!REPLACE!!", "PS4": "> "},
+    "notify": ["github_commit_status"],
+    "depends_on": null,
 }

--- a/ray_ci/step.json
+++ b/ray_ci/step.json
@@ -4,7 +4,7 @@
             "ray-project/dind#v1.0.10": {
                 "network-name": "dind-network",
                 "certs-volume-name": "ray-docker-certs-client",
-                "additional-volume-mount": "ray-volume:/ray",
+                "additional-volume-mount": "ray-volume:/ray"
             }
         },
         {
@@ -21,7 +21,7 @@
                 "volumes": [
                     "ray-docker-certs-client:/certs/client:ro",
                     "ray-volume:/ray-mount",
-                    "/tmp/artifacts:/artifact-mount",
+                    "/tmp/artifacts:/artifact-mount"
                 ],
                 "environment": [
                     "BUILDKITE_JOB_ID",
@@ -34,10 +34,10 @@
                     "BUILDKITE_PARALLEL_JOB_COUNT",
                     "BUILDKITE_MESSAGE",
                     "BUILDKITE_BUILD_NUMBER",
-                    "PS4",
-                ],
+                    "PS4"
+                ]
             }
-        },
+        }
     ],
     "agents": {"queue": "!!REPLACE!!"},
     "timeout_in_minutes": 180,
@@ -45,11 +45,11 @@
         "manual": {"permit_on_passed": true},
         "automatic": [
             {"exit_status": -1, "limit": 3},
-            {"exit_status": 255, "limit": 3},
-        ],
+            {"exit_status": 255, "limit": 3}
+        ]
     },
     "artifact_paths": "/tmp/artifacts/.*/**",
     "env": {"BUILDKITE_ARTIFACT_UPLOAD_DESTINATION": "!!REPLACE!!", "PS4": "> "},
     "notify": ["github_commit_status"],
-    "depends_on": null,
+    "depends_on": null
 }

--- a/ray_ci/test_pipeline_ci.py
+++ b/ray_ci/test_pipeline_ci.py
@@ -121,12 +121,15 @@ def test_create_setup_commands():
     commands = create_setup_commands(
         repo_url="SOME_URL", repo_branch="SOME_BRANCH", git_hash="abcd1234"
     )
-    cmds_before_git = 5
+    cmds_before_git = 4
 
-    assert commands[-cmds_before_git - 3] == "git remote add pr_repo SOME_URL"
-    assert commands[-cmds_before_git - 2] == "git fetch pr_repo SOME_BRANCH"
-    assert commands[-cmds_before_git - 1] == "git checkout pr_repo/SOME_BRANCH"
-    assert "abcd1234" in commands[-cmds_before_git]
+    assert commands[-cmds_before_git - 4] == "git remote add pr_repo SOME_URL"
+    assert commands[-cmds_before_git - 3] == "git fetch pr_repo SOME_BRANCH"
+    assert commands[-cmds_before_git - 2] == "git checkout pr_repo/SOME_BRANCH"
+    assert "abcd1234" in commands[-cmds_before_git - 1]
+    assert commands[-cmds_before_git].startswith(
+        "git checkout master python/ray/_raylet.pxd python/ray/_raylet.pyi"
+    )
 
 
 def test_pipeline_map_steps():

--- a/ray_ci/test_pipeline_ci.py
+++ b/ray_ci/test_pipeline_ci.py
@@ -121,7 +121,7 @@ def test_create_setup_commands():
     commands = create_setup_commands(
         repo_url="SOME_URL", repo_branch="SOME_BRANCH", git_hash="abcd1234"
     )
-    cmds_before_git = 4
+    cmds_before_git = 5
 
     assert commands[-cmds_before_git - 3] == "git remote add pr_repo SOME_URL"
     assert commands[-cmds_before_git - 2] == "git fetch pr_repo SOME_BRANCH"


### PR DESCRIPTION
This PR fixes [broken early kickoff tests](https://github.com/ray-project/ray/issues/31476) in two ways:

1. We checkout some original files from the master branch (i.e. the base early kick off image) before running the test. This should restore compatibility with the compiled raylet in most cases (some major API changes will not be found)
2. Add a `[no_early_kickoff]` flag that disables early kick off

Closes https://github.com/ray-project/ray/issues/31476