### PR TITLE
Add Docker-in-Docker support for Ecosystem pipelines

### DIFF
--- a/ecosystem_ci/build_pipeline.py
+++ b/ecosystem_ci/build_pipeline.py
@@ -45,8 +45,8 @@ def job_to_step(base_step: Dict, job: Dict) -> Dict:
 
     image = job.pop(SPECIAL_FIELD_IMAGE, None)
     if image:
-        docker_key = list(base_step["plugins"][0].keys())[0]
-        step["plugins"][0][docker_key]["image"] = image
+        docker_key = list(base_step["plugins"][1].keys())[0]
+        step["plugins"][1][docker_key]["image"] = image
 
     instance_size = job.pop(SPECIAL_FIELD_INSTANCE_SIZE, DEFAULT_INSTANCE_SIZE)
     try:

--- a/ecosystem_ci/step.json
+++ b/ecosystem_ci/step.json
@@ -34,7 +34,11 @@
 					"BUILDKITE_PARALLEL_JOB_COUNT",
 					"BUILDKITE_MESSAGE",
 					"BUILDKITE_BUILD_NUMBER",
-					"PS4"
+					"PS4",
+					"DOCKER_TLS_CERTDIR=/certs",
+					"DOCKER_HOST=tcp://docker:2376",
+					"DOCKER_TLS_VERIFY=1",
+					"DOCKER_CERT_PATH=/certs/client",
 				],
 				"volumes": [
                     "ray-docker-certs-client:/certs/client:ro",

--- a/ecosystem_ci/step.json
+++ b/ecosystem_ci/step.json
@@ -23,6 +23,7 @@
 				"add-caps": [
 					"SYS_PTRACE"
 				],
+				"network": "dind-network",
 				"environment": [
 					"BUILDKITE_JOB_ID",
 					"BUILDKITE_COMMIT",

--- a/ecosystem_ci/step.json
+++ b/ecosystem_ci/step.json
@@ -38,7 +38,7 @@
 					"DOCKER_TLS_CERTDIR=/certs",
 					"DOCKER_HOST=tcp://docker:2376",
 					"DOCKER_TLS_VERIFY=1",
-					"DOCKER_CERT_PATH=/certs/client",
+					"DOCKER_CERT_PATH=/certs/client"
 				],
 				"volumes": [
                     "ray-docker-certs-client:/certs/client:ro",

--- a/ecosystem_ci/step.json
+++ b/ecosystem_ci/step.json
@@ -1,36 +1,49 @@
 {
 	"plugins": [{
-		"docker#v5.3.0": {
-			"image": "ubuntu:latest",
-			"shell": [
-				"/bin/bash",
-				"-e",
-				"-c",
-				"-i",
-				"-l"
-			],
-			"shm-size": "2.5gb",
-			"propagate-environment": false,
-			"mount-checkout": true,
-			"mount-buildkite-agent": false,
-			"add-caps": [
-				"SYS_PTRACE"
-			],
-			"environment": [
-				"BUILDKITE_JOB_ID",
-				"BUILDKITE_COMMIT",
-				"BUILDKITE_LABEL",
-				"BUILDKITE_BRANCH",
-				"BUILDKITE_BUILD_URL",
-				"BUILDKITE_BUILD_ID",
-				"BUILDKITE_PARALLEL_JOB",
-				"BUILDKITE_PARALLEL_JOB_COUNT",
-				"BUILDKITE_MESSAGE",
-				"BUILDKITE_BUILD_NUMBER",
-				"PS4"
-			]
+			"ray-project/dind#v1.0.10": {
+				"network-name": "dind-network",
+				"certs-volume-name": "ray-docker-certs-client",
+				"additional-volume-mount": "shared-ci-volume:/shared"
+			}
+		},
+		{
+			"docker#v5.3.0": {
+				"image": "ubuntu:latest",
+				"shell": [
+					"/bin/bash",
+					"-e",
+					"-c",
+					"-i",
+					"-l"
+				],
+				"shm-size": "2.5gb",
+				"propagate-environment": false,
+				"mount-checkout": true,
+				"mount-buildkite-agent": false,
+				"add-caps": [
+					"SYS_PTRACE"
+				],
+				"environment": [
+					"BUILDKITE_JOB_ID",
+					"BUILDKITE_COMMIT",
+					"BUILDKITE_LABEL",
+					"BUILDKITE_BRANCH",
+					"BUILDKITE_BUILD_URL",
+					"BUILDKITE_BUILD_ID",
+					"BUILDKITE_PARALLEL_JOB",
+					"BUILDKITE_PARALLEL_JOB_COUNT",
+					"BUILDKITE_MESSAGE",
+					"BUILDKITE_BUILD_NUMBER",
+					"PS4"
+				],
+				"volumes": [
+                    "ray-docker-certs-client:/certs/client:ro",
+                    "shared-ci-volume:/shared",
+                    "/tmp/artifacts:/artifact-mount"
+                ]
+			}
 		}
-	}],
+	],
 	"agents": {
 		"queue": "runner_queue_pr"
 	},

--- a/ecosystem_ci/step.json
+++ b/ecosystem_ci/step.json
@@ -42,10 +42,10 @@
 					"DOCKER_CERT_PATH=/certs/client"
 				],
 				"volumes": [
-                    "ray-docker-certs-client:/certs/client:ro",
-                    "shared-ci-volume:/shared",
-                    "/tmp/artifacts:/artifact-mount"
-                ]
+					"ray-docker-certs-client:/certs/client:ro",
+					"shared-ci-volume:/shared",
+					"/tmp/artifacts:/artifact-mount"
+				]
 			}
 		}
 	],


### PR DESCRIPTION
KubeRay needs Docker in Docker to run their test suites.

This PR updates the ecosystem pipelines to start a dind daemon and connect to it.

Here is an example on how to use it: https://github.com/krfricke/ray-ecosystem-dev/commit/511782b9e7df15dd7ca4b59152826dfd10f56678

The pipeline needs to run on an image that either has docker installed or can install docker later.

Any docker _builds_ must happen in the `/shared` directory, which is shared between the host VM and the docker container running on CI.

For example, here we just start a ubuntu container and call a `install_docker.sh` script that installs docker. The `build.sh` image will then later build a docker image.

```
- label: Second pipeline
  commands:
    - echo Second command
    - bash install_docker.sh
    - docker ps
    - bash build.sh custom_image
    - docker run -t --rm custom_image cat /tmp/yeah
  instance_size: small 
  image: ubuntu:focal
```

Example for installing docker (`install_docker.sh`):

```
#!/bin/bash

export DEBIAN_FRONTEND=noninteractive
export TZ=America/Los_Angeles

export locale -a
export LC_ALL=en_US.utf8
export LANG=en_US.utf8

apt-get update -qq && apt-get upgrade -qq
apt-get install -y -qq \
    curl python-is-python3 git build-essential \
    sudo unzip unrar apt-utils dialog tzdata wget rsync \
    language-pack-en tmux

curl -o- https://get.docker.com | sh
```

Example for building a Docker image (`build.sh`):

```
#!/bin/bash

SHARED_DIR=/shared

rm -rf $SHARED_DIR/*
cp -rf ./docker $SHARED_DIR
pushd $SHARED_DIR/docker
docker build -t "$1" .
popd
```

IMPORTANT: The `/shared` directory is shared between the Host system (running on the VM) and the Docker container running in CI! This is where you have to put all the data required for building the image (such as the Dockerfile).


