### PR TITLE
Make buildkite run container in privileged way

### DIFF
--- a/ray_ci/step_linux.json
+++ b/ray_ci/step_linux.json
@@ -17,6 +17,7 @@
                 "mount-buildkite-agent": false,
                 "workdir": "/ray",
                 "add-caps": ["SYS_PTRACE", "CAP_SYS_ADMIN", "NET_ADMIN"],
+                "privileged": true,
                 "network": "dind-network",
                 "volumes": [
                     "ray-docker-certs-client:/certs/client:ro",


### PR DESCRIPTION
This PR enable the container to run in a privileged way. Privileged is required to run CI test in parallel which will come in OSS PR.