### PR TITLE
Add `apparmor=unconfined` to container

### DIFF
--- a/ray_ci/step_linux.json
+++ b/ray_ci/step_linux.json
@@ -16,7 +16,8 @@
                 "mount-checkout": false,
                 "mount-buildkite-agent": false,
                 "workdir": "/ray",
-                "add-caps": ["SYS_PTRACE", "CAP_SYS_ADMIN", "NET_ADMIN"],
+                "add-caps": ["SYS_PTRACE", "SYS_ADMIN", "NET_ADMIN"],
+                "security-opt": ["apparmor=unconfined"],
                 "network": "dind-network",
                 "volumes": [
                     "ray-docker-certs-client:/certs/client:ro",

--- a/ray_ci/step_linux.json
+++ b/ray_ci/step_linux.json
@@ -17,7 +17,7 @@
                 "mount-buildkite-agent": false,
                 "workdir": "/ray",
                 "add-caps": ["SYS_PTRACE", "SYS_ADMIN", "NET_ADMIN"],
-                "security-opt": ["apparmor=unconfined"],
+                "security-opts": ["apparmor=unconfined"],
                 "network": "dind-network",
                 "volumes": [
                     "ray-docker-certs-client:/certs/client:ro",


### PR DESCRIPTION
This PR added `apparmor=unconfined` to container so that it can mount the root. With this we should isolate the tests and put each test into a sandbox.