### PR TITLE
Increase build timeout on CI to 5 hours.

### DIFF
--- a/ray_ci/step_linux.json
+++ b/ray_ci/step_linux.json
@@ -41,7 +41,7 @@
         }
     ],
     "agents": {"queue": "!!REPLACE!!"},
-    "timeout_in_minutes": 180,
+    "timeout_in_minutes": 300,
     "retry": {
         "manual": {"permit_on_passed": true},
         "automatic": [


### PR DESCRIPTION
This is required to build all docker images when horrible cache misses.