### PR TITLE
Don't restore code to older version.

### DIFF
--- a/ray_ci/pipeline_ci.py
+++ b/ray_ci/pipeline_ci.py
@@ -9,17 +9,6 @@ from typing import Any, Callable, Dict, List, Optional, Set
 import click
 import yaml
 
-# On early kick off, restore these files to their original state for compatibility
-EARLY_KICKOFF_KEEP_ORIG = [
-    "python/ray/_raylet.pxd",
-    "python/ray/_raylet.pyi",
-    "python/ray/_raylet.pyx",
-    "python/ray/_private/",
-    "python/ray/actor.py",
-    "python/ray/runtime_context.py",
-    "python/ray/remote_function.py",
-]
-
 
 EARLY_SETUP_COMMANDS = [
     "echo '--- :running: Early kick-off: Checking out PR code revision'",
@@ -30,8 +19,6 @@ EARLY_SETUP_COMMANDS = [
         '[[ "$(git log -1 --format="%H")" == "{git_hash}" ]] || '
         '(echo "Quick start failed: Wrong commit hash!" && exit 1)'
     ),
-    # Keep _raylet files from original image
-    "git checkout master " + " ".join(EARLY_KICKOFF_KEEP_ORIG),
     "BAZEL_CONFIG_ONLY=1 ./ci/env/install-bazel.sh",
     'echo "build --remote_upload_local_results=false" >> /root/.bazelrc',
     "echo 'export PS4=\"> \"' >> ~/.bashrc",

--- a/ray_ci/test_pipeline_ci.py
+++ b/ray_ci/test_pipeline_ci.py
@@ -121,15 +121,12 @@ def test_create_setup_commands():
     commands = create_setup_commands(
         repo_url="SOME_URL", repo_branch="SOME_BRANCH", git_hash="abcd1234"
     )
-    cmds_before_git = 4
+    cmds_before_git = 3
 
     assert commands[-cmds_before_git - 4] == "git remote add pr_repo SOME_URL"
     assert commands[-cmds_before_git - 3] == "git fetch pr_repo SOME_BRANCH"
     assert commands[-cmds_before_git - 2] == "git checkout pr_repo/SOME_BRANCH"
     assert "abcd1234" in commands[-cmds_before_git - 1]
-    assert commands[-cmds_before_git].startswith(
-        "git checkout master python/ray/_raylet.pxd python/ray/_raylet.pyi"
-    )
 
 
 def test_pipeline_map_steps():


### PR DESCRIPTION
Early kick off is only designed for skipping building the wheel. It should never change the source code of the repository after checking out.

A git commit is always suppose to work in a coherent version, mutating the source code in this way is just inviting confusion.