### PR TITLE
Require opt-in for early kickoff

### DIFF
--- a/ray_ci/bootstrap_linux.sh
+++ b/ray_ci/bootstrap_linux.sh
@@ -12,6 +12,11 @@ fi
 
 # Commit message instructions
 
+if [[ "$BUILDKITE_MESSAGE" =~ "[early_kickoff]" ]]; then
+   echo "Got early kickoff trigger - enabling early kickoff (if possible)!"
+   export KICK_OFF_EARLY="1"
+fi
+
 if [[ "$BUILDKITE_MESSAGE" =~ "[build_base]" ]]; then
    echo "Got build base trigger - rebuilding base images!"
    export BUILD_OWN_BASE="1"
@@ -23,11 +28,6 @@ fi
 if [[ "$BUILDKITE_MESSAGE" =~ "[all_tests]" ]]; then
    echo "Got all tests trigger - running all tests!"
    export ALL_TESTS="1"
-fi
-
-if [[ "$BUILDKITE_MESSAGE" =~ "[no_early_kickoff]" ]]; then
-   echo "Got no early kickoff trigger - preventing early kickoff!"
-   export KICK_OFF_EARLY="0"
 fi
 
 # Convert / into _

--- a/ray_ci/bootstrap_linux_cpu_gpu.sh
+++ b/ray_ci/bootstrap_linux_cpu_gpu.sh
@@ -5,10 +5,12 @@ echo "--- :alarm_clock: Determine if we should kick-off some steps early"
 
 # On pull requests, allow to run on latest available image if wheels are not affected
 if [ "${BUILDKITE_PULL_REQUEST}" != "false" ] && [ "$RAY_CI_CORE_CPP_AFFECTED" != "1" ] && [ "$RAY_CI_PYTHON_DEPENDENCIES_AFFECTED" != "1" ] && [ "$RAY_CI_COMPILED_PYTHON_AFFECTED" != "1" ]; then
-  export KICK_OFF_EARLY=${KICK_OFF_EARLY:-1}
+  # Default to 0 (disabled, have to opt-in via [early_kickoff])
+  export KICK_OFF_EARLY=${KICK_OFF_EARLY:-0}
 
   if [ "${KICK_OFF_EARLY}" = "1" ]; then
-    echo "Kicking off some tests early, as this is a PR, and the core C++ is not affected, and requirements are not affected. "
+    echo "Kicking off some tests early, as it was requested. "
+    echo "Also, this is a PR, core C++ is not affected, and requirements are not affected. "
   else
     echo "We could kick off tests early, but we were asked not to (KICK_OFF_EARLY=${KICK_OFF_EARLY}), so we don't."
   fi


### PR DESCRIPTION
Early kickoff currently suffers more often from mismatch between core files and library files. Until this is resolved, we should disable automatic early kick off and only enable on opt-in.

Closes #19, closes #20