### PR TITLE
Scripts for tracking external code changes

### DIFF
--- a/external_code_tracker/glue.js
+++ b/external_code_tracker/glue.js
@@ -43,7 +43,7 @@ let changedFileToURIs = filterFilesByNames(trackedFilesToURIs, changedFiles);
 console.log("changedFileToURIs")
 console.log(changedFileToURIs)
 
-if (changedFileToURIs.length === 0) {
+if (!changedFileToURIs.length) {
   if (commentToUpdate) {
       commentBody = getCommentContentNotChanged(commentHeader);
       await github.rest.issues.updateComment({

--- a/external_code_tracker/glue.js
+++ b/external_code_tracker/glue.js
@@ -1,0 +1,74 @@
+const {
+  deserializeIntoArray,
+  filterFilesByNames,
+  getCommentContentChanged,
+  getCommentContentNotChanged,
+  parseTrackedFilesToURIs,
+  readFileContent
+} = require('./track_code');
+
+
+const commentHeader = `## Attention: External code changed`
+
+// Get existing comments
+const existingComments = await github.rest.issues.listComments({
+  owner: context.repo.owner,
+  repo: context.repo.repo,
+  issue_number: context.issue.number
+});
+
+// Find comment by the bot that starts with the header
+let commentToUpdate = existingComments.data.find(comment =>
+  comment.user.login === 'github-actions[bot]' && comment.body.startsWith(commentHeader)
+);
+
+// Read and parse external_code.txt file
+let externCodeFileContent = readFileContent("doc/external/external_code.txt");
+let trackedFilesToURIs = parseTrackedFilesToURIs(externCodeFileContent);
+
+// Get changed files from environment variable
+let changedFiles = await deserializeIntoArray(process.env.GIT_DIFF_SERIALIZED)
+
+// Filter associative array
+let changedFileToURIs = filterFilesByNames(trackedFilesToURIs, changedFiles);
+
+if (!changedFileToURIs) {
+  if (commentToUpdate) {
+      commentContent = getCommentContentNotChanged(commentHeader);
+      await github.rest.issues.updateComment({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        comment_id: commentToUpdate.id,
+        body: commentBody
+      });
+  }
+
+} else {
+    commentContent = getCommentContentChanged(commentHeader, changedFileToURIs);
+
+    if (commentToUpdate) {
+    // Only update if content changed
+    if (commentBody !== commentToUpdate.body) {
+      await github.rest.issues.updateComment({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        comment_id: commentToUpdate.id,
+        body: commentBody
+      });
+    }
+  } else {
+    await github.rest.issues.createComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: context.issue.number,
+      body: commentBody
+    });
+  }
+  await github.rest.issues.addLabels({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    issue_number: context.issue.number,
+    labels: ['external-code-affected']
+  });
+
+}

--- a/external_code_tracker/glue.js
+++ b/external_code_tracker/glue.js
@@ -43,7 +43,7 @@ let changedFileToURIs = filterFilesByNames(trackedFilesToURIs, changedFiles);
 console.log("changedFileToURIs")
 console.log(changedFileToURIs)
 
-if (!changedFileToURIs) {
+if (changedFileToURIs.length === 0) {
   if (commentToUpdate) {
       commentBody = getCommentContentNotChanged(commentHeader);
       await github.rest.issues.updateComment({

--- a/external_code_tracker/glue.js
+++ b/external_code_tracker/glue.js
@@ -43,7 +43,7 @@ let changedFileToURIs = filterFilesByNames(trackedFilesToURIs, changedFiles);
 console.log("changedFileToURIs")
 console.log(changedFileToURIs)
 
-if (!changedFileToURIs.length) {
+if (Object.keys(changedFileToURIs).length === 0) {
   if (commentToUpdate) {
       commentBody = getCommentContentNotChanged(commentHeader);
       await github.rest.issues.updateComment({

--- a/external_code_tracker/glue.js
+++ b/external_code_tracker/glue.js
@@ -28,11 +28,20 @@ let commentToUpdate = existingComments.data.find(comment =>
 let externCodeFileContent = fs.readFileSync(externalCodeFile, "utf8");
 let trackedFilesToURIs = parseTrackedFilesToURIs(externCodeFileContent);
 
+console.log("trackedFileToURIs")
+console.log(trackedFilesToURIs)
+
 // Get changed files from environment variable
 let changedFiles = await deserializeIntoArray(process.env.GIT_DIFF_SERIALIZED)
 
+console.log("changedFiles")
+console.log(changedFiles)
+
 // Filter associative array
 let changedFileToURIs = filterFilesByNames(trackedFilesToURIs, changedFiles);
+
+console.log("changedFileToURIs")
+console.log(changedFileToURIs)
 
 if (!changedFileToURIs) {
   if (commentToUpdate) {

--- a/external_code_tracker/glue.js
+++ b/external_code_tracker/glue.js
@@ -10,6 +10,7 @@ const {
 const fs = require("fs");
 
 const commentHeader = `## Attention: External code changed`
+const externalCodeFile = "doc/external/external_code.txt"
 
 // Get existing comments
 const existingComments = await github.rest.issues.listComments({
@@ -24,7 +25,7 @@ let commentToUpdate = existingComments.data.find(comment =>
 );
 
 // Read and parse external_code.txt file
-let externCodeFileContent = fs.readFileSync("doc/external/external_code.txt", "utf8");
+let externCodeFileContent = fs.readFileSync(externalCodeFile, "utf8");
 let trackedFilesToURIs = parseTrackedFilesToURIs(externCodeFileContent);
 
 // Get changed files from environment variable
@@ -35,7 +36,7 @@ let changedFileToURIs = filterFilesByNames(trackedFilesToURIs, changedFiles);
 
 if (!changedFileToURIs) {
   if (commentToUpdate) {
-      commentContent = getCommentContentNotChanged(commentHeader);
+      commentBody = getCommentContentNotChanged(commentHeader);
       await github.rest.issues.updateComment({
         owner: context.repo.owner,
         repo: context.repo.repo,
@@ -45,7 +46,7 @@ if (!changedFileToURIs) {
   }
 
 } else {
-    commentContent = getCommentContentChanged(commentHeader, changedFileToURIs);
+    commentBody = getCommentContentChanged(commentHeader, changedFileToURIs);
 
     if (commentToUpdate) {
     // Only update if content changed

--- a/external_code_tracker/glue.js
+++ b/external_code_tracker/glue.js
@@ -7,6 +7,7 @@ const {
   readFileContent
 } = require('./track_code');
 
+const fs = require("fs");
 
 const commentHeader = `## Attention: External code changed`
 
@@ -23,7 +24,7 @@ let commentToUpdate = existingComments.data.find(comment =>
 );
 
 // Read and parse external_code.txt file
-let externCodeFileContent = readFileContent("doc/external/external_code.txt");
+let externCodeFileContent = fs.readFileSync("doc/external/external_code.txt", "utf8");
 let trackedFilesToURIs = parseTrackedFilesToURIs(externCodeFileContent);
 
 // Get changed files from environment variable

--- a/external_code_tracker/test_track_code.js
+++ b/external_code_tracker/test_track_code.js
@@ -6,20 +6,13 @@ const {
   filterFilesByNames,
   getCommentContentChanged,
   getCommentContentNotChanged,
-  parseTrackedFilesToURIs,
-  readFileContent
+  parseTrackedFilesToURIs
 } = require("./track_code");
 
 // Testing deserializeIntoArray function
 assert.deepStrictEqual(deserializeIntoArray("1||2||3"), ["1", "2", "3"]);
 assert.deepStrictEqual(deserializeIntoArray("1||2||3||", "||"), ["1", "2", "3"]);
 assert.deepStrictEqual(deserializeIntoArray("||1||2||3||", "||"), ["1", "2", "3"]);
-
-// Testing readFileContent function
-// Create a dummy file and use it for the test
-fs.writeFileSync("test.txt", "Hello, World!", "utf8");
-assert.strictEqual(readFileContent("test.txt"), "Hello, World!");
-fs.unlinkSync("test.txt"); // clean up after test
 
 // Testing parseTrackedFilesToURIs function
 const sampleContent = `

--- a/external_code_tracker/test_track_code.js
+++ b/external_code_tracker/test_track_code.js
@@ -1,0 +1,75 @@
+// utils.test.js
+const assert = require("assert");
+const fs = require("fs");
+const {
+  deserializeIntoArray,
+  filterFilesByNames,
+  getCommentContentChanged,
+  getCommentContentNotChanged,
+  parseTrackedFilesToURIs,
+  readFileContent
+} = require("./track_code");
+
+// Testing deserializeIntoArray function
+assert.deepStrictEqual(deserializeIntoArray("1||2||3"), ["1", "2", "3"]);
+assert.deepStrictEqual(deserializeIntoArray("1||2||3||", "||"), ["1", "2", "3"]);
+assert.deepStrictEqual(deserializeIntoArray("||1||2||3||", "||"), ["1", "2", "3"]);
+
+// Testing readFileContent function
+// Create a dummy file and use it for the test
+fs.writeFileSync("test.txt", "Hello, World!", "utf8");
+assert.strictEqual(readFileContent("test.txt"), "Hello, World!");
+fs.unlinkSync("test.txt"); // clean up after test
+
+// Testing parseTrackedFilesToURIs function
+const sampleContent = `
+# Comment
+file1 http://example1.com
+file2 http://example2.com
+# Another comment
+file3 http://example3.com
+`;
+let expectedArray = {
+  "file1": "http://example1.com",
+  "file2": "http://example2.com",
+  "file3": "http://example3.com"
+};
+assert.deepStrictEqual(parseTrackedFilesToURIs(sampleContent), expectedArray);
+
+// Testing filterFilesByNames function
+const filesToURIs = {
+  "file1": "http://example1.com",
+  "file2": "http://example2.com",
+  "file3": "http://example3.com"
+};
+const filenames = ["file1", "file3"];
+let expectedArray2 = {
+  "file1": "http://example1.com",
+  "file3": "http://example3.com"
+};
+assert.deepStrictEqual(filterFilesByNames(filesToURIs, filenames), expectedArray2);
+
+// Testing getCommentContentNotChanged function
+const commentHeader = "## Attention: External code changed";
+let expectedOutput = `${commentHeader}
+
+A previous version of this PR changed code that is used or cited in  external sources, e.g. blog posts.
+
+It looks like these changes have been reverted or are otherwise not present in this PR anymore. Please still carefully review the changes to make sure code we use in external sources still works.`;
+assert.strictEqual(getCommentContentNotChanged(commentHeader), expectedOutput);
+
+// Testing getCommentContentChanged function
+const changedFilesToURIs = {
+  "file1": "http://example1.com",
+  "file3": "http://example3.com"
+};
+let expectedOutput2 = `${commentHeader}
+
+This PR changes code that is used or cited in external sources, e.g. blog posts.
+
+Before merging this PR, please make sure that the code in the external sources is still working, and consider updating them to reflect the changes.
+
+The affected files and the external sources are:
+- \`file1\`: http://example1.com
+- \`file3\`: http://example3.com`;
+assert.strictEqual(getCommentContentChanged(commentHeader, changedFilesToURIs), expectedOutput2);

--- a/external_code_tracker/test_track_code.js
+++ b/external_code_tracker/test_track_code.js
@@ -11,8 +11,8 @@ const {
 
 // Testing deserializeIntoArray function
 assert.deepStrictEqual(deserializeIntoArray("1||2||3"), ["1", "2", "3"]);
-assert.deepStrictEqual(deserializeIntoArray("1||2||3||", "||"), ["1", "2", "3"]);
-assert.deepStrictEqual(deserializeIntoArray("||1||2||3||", "||"), ["1", "2", "3"]);
+assert.deepStrictEqual(deserializeIntoArray("1||2||3||", "|"), ["1", "2", "3"]);
+assert.deepStrictEqual(deserializeIntoArray("||1||2||3||", "|"), ["1", "2", "3"]);
 
 // Testing parseTrackedFilesToURIs function
 const sampleContent = `

--- a/external_code_tracker/track_code.js
+++ b/external_code_tracker/track_code.js
@@ -1,0 +1,78 @@
+const fs = require("fs");
+const path = require("path");
+
+// Define patterns
+const filePattern = /^[a-zA-Z0-9_/.-]+$/;
+const uriPattern = /^https?:\/\/[a-zA-Z0-9._:/&#-]+$/;
+
+function deserializeIntoArray(string, delimiter="||") {
+  return string.split(delimiter).filter(item => item.trim() !== "");
+}
+
+function readFileContent(filename) {
+  const filePath = path.resolve(__dirname, filename);
+  return fs.readFileSync(filePath, "utf8");
+}
+
+function parseTrackedFilesToURIs(content) {
+  let lines = content.split("\n");
+  let filesToExternalUri = {};
+
+  for (let line of lines) {
+    // Skip comments and empty lines
+    if (line.startsWith("#") || line.trim() === "") {
+      continue;
+    }
+
+    let [file, uri] = line.split(" ").map(s => s.trim());
+
+    // Check that these conform to expected patterns
+    if (!filePattern.test(file) || !uriPattern.test(uri)) {
+      throw new Error(`Invalid file path or URI detected: ${file} ${uri}`);
+    }
+
+    filesToExternalUri[file] = uri;
+  }
+  return filesToExternalUri;
+}
+
+function filterFilesByNames(filesToURIs, filenames) {
+  let result = {};
+  Object.keys(filesToURIs).filter(file => filenames.includes(file)).forEach(file => {
+    result[file] = filesToURIs[file];
+  });
+  return result;
+}
+
+function getCommentContentNotChanged(commentHeader) {
+  return `${commentHeader}
+
+A previous version of this PR changed code that is used or cited in  external sources, e.g. blog posts.
+
+It looks like these changes have been reverted or are otherwise not present in this PR anymore. Please still carefully review the changes to make sure code we use in external sources still works.`;
+}
+
+function getCommentContentChanged(commentHeader, changedFilesToURIs) {
+  var commentBody = `${commentHeader}
+
+This PR changes code that is used or cited in external sources, e.g. blog posts.
+
+Before merging this PR, please make sure that the code in the external sources is still working, and consider updating them to reflect the changes.
+
+The affected files and the external sources are:`;
+
+  for (let file in changedFilesToURIs) {
+    const fileMessage = `- \`${file}\`: ${changedFilesToURIs[file]}`;
+    commentBody += `\n${fileMessage}`;
+  }
+  return commentBody;
+}
+
+module.exports = {
+  deserializeIntoArray,
+  filterFilesByNames,
+  getCommentContentChanged,
+  getCommentContentNotChanged,
+  parseTrackedFilesToURIs,
+  readFileContent
+};

--- a/external_code_tracker/track_code.js
+++ b/external_code_tracker/track_code.js
@@ -1,17 +1,9 @@
-const fs = require("fs");
-const path = require("path");
-
 // Define patterns
 const filePattern = /^[a-zA-Z0-9_/.-]+$/;
 const uriPattern = /^https?:\/\/[a-zA-Z0-9._:/&#-]+$/;
 
 function deserializeIntoArray(string, delimiter="||") {
   return string.split(delimiter).filter(item => item.trim() !== "");
-}
-
-function readFileContent(filename) {
-  const filePath = path.resolve(__dirname, filename);
-  return fs.readFileSync(filePath, "utf8");
 }
 
 function parseTrackedFilesToURIs(content) {
@@ -73,6 +65,5 @@ module.exports = {
   filterFilesByNames,
   getCommentContentChanged,
   getCommentContentNotChanged,
-  parseTrackedFilesToURIs,
-  readFileContent
+  parseTrackedFilesToURIs
 };

--- a/external_code_tracker/track_code.js
+++ b/external_code_tracker/track_code.js
@@ -2,7 +2,7 @@
 const filePattern = /^[a-zA-Z0-9_/.-]+$/;
 const uriPattern = /^https?:\/\/[a-zA-Z0-9._:/&#-]+$/;
 
-function deserializeIntoArray(string, delimiter="||") {
+function deserializeIntoArray(string, delimiter="|") {
   return string.split(delimiter).filter(item => item.trim() !== "");
 }
 


### PR DESCRIPTION
As discussed in https://github.com/ray-project/ray/pull/35261, we should keep the logic to check for changed files in a separate, testable repository.