### PR TITLE
Add grouping support for ray CI pipeline.

### DIFF
--- a/ray_ci/test_pipeline_ci.py
+++ b/ray_ci/test_pipeline_ci.py
@@ -213,6 +213,14 @@ def test_read_lineline():
         assert group_name is None
         assert steps == [{"name": "foo"}]
 
+    with tempfile.TemporaryDirectory() as tmpdir:
+        pipeline_path = Path(os.path.join(tmpdir, "pipeline.yml"))
+        with open(pipeline_path, "w") as f:
+            f.write("steps:\n  - name: foo\n")
+        steps, group_name = read_pipeline(pipeline_path)
+        assert group_name is None
+        assert steps == [{"name": "foo"}]
+
 
 
 if __name__ == "__main__":

--- a/ray_ci/test_pipeline_ci.py
+++ b/ray_ci/test_pipeline_ci.py
@@ -1,8 +1,10 @@
 import json
 import os
 
+from pathlib import Path
 import pytest
 import sys
+import tempfile
 
 from typing import List
 
@@ -14,6 +16,7 @@ from pipeline_ci import (
     map_commands,
     DEFAULT_BASE_STEPS_JSON,
     _update_step,
+    read_pipeline,
 )
 
 
@@ -191,6 +194,25 @@ def test_pipeline_update_queue():
     # Cleanup
     os.environ.pop("RUNNER_QUEUE_DEFAULT", None)
     os.environ.pop("RUNNER_QUEUE_SMALL", None)
+
+
+def test_read_lineline():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        pipeline_path = Path(os.path.join(tmpdir, "pipeline.yml"))
+        with open(pipeline_path, "w") as f:
+            f.write("#ci:group=foo")
+        steps, group_name = read_pipeline(pipeline_path)
+        assert group_name == "foo"
+        assert steps == []
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        pipeline_path = Path(os.path.join(tmpdir, "pipeline.yml"))
+        with open(pipeline_path, "w") as f:
+            f.write("- name: foo")
+        steps, group_name = read_pipeline(pipeline_path)
+        assert group_name is None
+        assert steps == [{"name": "foo"}]
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
So that we can support grouping.

One can add a `#ci:group=MY_GROUP_NAME` to put all the steps into a group with name `MY_GROUP_NAME`.