### PR TITLE
make it possible to break pipeline.build.yml into multiple files.

### DIFF
--- a/ray_ci/bootstrap_linux_cpu_gpu.sh
+++ b/ray_ci/bootstrap_linux_cpu_gpu.sh
@@ -94,8 +94,11 @@ fi
 echo "--- :rocket: Launching BUILD tests :gear:"
 echo "Kicking off the full BUILD pipeline"
 
-python3 "${PIPELINE_REPO_DIR}/ray_ci/pipeline_ci.py" --image "$DOCKER_IMAGE_BUILD" --queue "$RUNNER_QUEUE_DEFAULT" \
-  "./.buildkite/pipeline.build.yml" | buildkite-agent pipeline upload
+for FILE in ".buildkite/pipeline.build*.yml" ; do
+  python3 "${PIPELINE_REPO_DIR}/ray_ci/pipeline_ci.py" \
+    --image "$DOCKER_IMAGE_BUILD" --queue "$RUNNER_QUEUE_DEFAULT" \
+    "$FILE" | buildkite-agent pipeline upload
+done
 
 
 # --- extract compiled Ray

--- a/ray_ci/bootstrap_linux_cpu_gpu.sh
+++ b/ray_ci/bootstrap_linux_cpu_gpu.sh
@@ -94,7 +94,8 @@ fi
 echo "--- :rocket: Launching BUILD tests :gear:"
 echo "Kicking off the full BUILD pipeline"
 
-for FILE in ".buildkite/pipeline.build*.yml" ; do
+BUILD_YAMLS=(.buildkite/pipeline.build*.yml)
+for FILE in "${BUILD_YAMLS[@])"; do
   python3 "${PIPELINE_REPO_DIR}/ray_ci/pipeline_ci.py" \
     --image "$DOCKER_IMAGE_BUILD" --queue "$RUNNER_QUEUE_DEFAULT" \
     "$FILE" | buildkite-agent pipeline upload

--- a/ray_ci/bootstrap_linux_cpu_gpu.sh
+++ b/ray_ci/bootstrap_linux_cpu_gpu.sh
@@ -95,7 +95,7 @@ echo "--- :rocket: Launching BUILD tests :gear:"
 echo "Kicking off the full BUILD pipeline"
 
 BUILD_YAMLS=(.buildkite/pipeline.build*.yml)
-for FILE in "${BUILD_YAMLS[@])"; do
+for FILE in "${BUILD_YAMLS[@]}"; do
   python3 "${PIPELINE_REPO_DIR}/ray_ci/pipeline_ci.py" \
     --image "$DOCKER_IMAGE_BUILD" --queue "$RUNNER_QUEUE_DEFAULT" \
     "$FILE" | buildkite-agent pipeline upload


### PR DESCRIPTION
`pipeline.build.yml` in ray is quite long, breaking it can make it possible to show as different groups.