### PR TITLE
only add groups when steps is not empty.

### DIFF
--- a/ray_ci/pipeline_ci.py
+++ b/ray_ci/pipeline_ci.py
@@ -302,13 +302,13 @@ def main(
         )
         pipeline_steps = inject_commands(pipeline_steps, before=setup_commands)
 
-    # Print to stdout
-    if group_name:
+    if group_name and len(pipeline_steps) > 0:
         pipeline_steps = [{
             "group": group_name,
             "steps": pipeline_steps,
         }]
 
+    # Print to stdout
     steps_str = json.dumps(pipeline_steps)
     print(steps_str)
 


### PR DESCRIPTION
otherwise, pipeline upload will get an error like:

https://buildkite.com/ray-project/oss-ci-build-pr/builds/26761#0188f9b3-880b-41c4-b098-7536ba58f92c